### PR TITLE
Add snapshot-controller Dockerfiles

### DIFF
--- a/Dockerfile.snapshot-controller.openshift
+++ b/Dockerfile.snapshot-controller.openshift
@@ -1,0 +1,8 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+WORKDIR /go/src/github.com/kubernetes-csi/external-snapshotter
+COPY . .
+RUN make build
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/kubernetes-csi/external-snapshotter/bin/snapshot-controller /usr/bin/
+ENTRYPOINT ["/usr/bin/snapshot-controller"]

--- a/Dockerfile.snapshot-controller.openshift.rhel7
+++ b/Dockerfile.snapshot-controller.openshift.rhel7
@@ -1,0 +1,8 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+WORKDIR /go/src/github.com/kubernetes-csi/external-snapshotter
+COPY . .
+RUN make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
+COPY --from=builder /go/src/github.com/kubernetes-csi/external-snapshotter/bin/snapshot-controller /usr/bin/
+ENTRYPOINT ["/usr/bin/snapshot-controller"]


### PR DESCRIPTION
Following csi-external-snapshotter sidecar as example.

Using `Dockerfile.snapshot-controller.openshift` as the base name.

@openshift/storage 