### PR TITLE
Bug 1883421: UPSTREAM: 381: Fix panic when source PVC does not exist

### DIFF
--- a/pkg/common-controller/snapshot_controller_base.go
+++ b/pkg/common-controller/snapshot_controller_base.go
@@ -317,6 +317,8 @@ func (ctrl *csiSnapshotCommonController) syncContentByKey(key string) error {
 
 // checkAndUpdateSnapshotClass gets the VolumeSnapshotClass from VolumeSnapshot. If it is not set,
 // gets it from default VolumeSnapshotClass and sets it.
+// On error, it must return the original snapshot, not nil, because the caller syncContentByKey
+// needs to check snapshot's timestamp.
 func (ctrl *csiSnapshotCommonController) checkAndUpdateSnapshotClass(snapshot *crdv1.VolumeSnapshot) (*crdv1.VolumeSnapshot, error) {
 	className := snapshot.Spec.VolumeSnapshotClassName
 	var class *crdv1.VolumeSnapshotClass
@@ -337,7 +339,7 @@ func (ctrl *csiSnapshotCommonController) checkAndUpdateSnapshotClass(snapshot *c
 		if err != nil {
 			klog.Errorf("checkAndUpdateSnapshotClass failed to setDefaultClass %v", err)
 			ctrl.updateSnapshotErrorStatusWithEvent(snapshot, v1.EventTypeWarning, "SetDefaultSnapshotClassFailed", fmt.Sprintf("Failed to set default snapshot class with error %v", err))
-			return nil, err
+			return snapshot, err
 		}
 	}
 

--- a/pkg/common-controller/snapshotclass_test.go
+++ b/pkg/common-controller/snapshotclass_test.go
@@ -86,6 +86,19 @@ func TestUpdateSnapshotClass(t *testing.T) {
 			},
 			test: testUpdateSnapshotClass,
 		},
+		{
+			// PVC does not exist
+			name:                  "1-5 - snapshot update with default class name failed because PVC was not found",
+			initialContents:       nocontents,
+			initialSnapshots:      newSnapshotArray("snap1-5", "snapuid1-5", "claim1-5", "", "", "", &True, nil, nil, nil, false, true, nil),
+			expectedSnapshots:     newSnapshotArray("snap1-5", "snapuid1-5", "claim1-5", "", "", "", &False, nil, nil, newVolumeError("Failed to set default snapshot class with error failed to retrieve PVC claim1-5 from the lister: \"persistentvolumeclaim \\\"claim1-5\\\" not found\""), false, true, nil),
+			initialClaims:         nil,
+			initialVolumes:        nil,
+			initialStorageClasses: []*storage.StorageClass{},
+			expectedEvents:        []string{"Warning SetDefaultSnapshotClassFailed"},
+			errors:                noerrors,
+			test:                  testUpdateSnapshotClass,
+		},
 	}
 
 	runUpdateSnapshotClassTests(t, tests, snapshotClasses)


### PR DESCRIPTION
checkAndUpdateSnapshotClass must always return a snapshot, even though it fails somewhere in ctrl.SetDefaultSnapshotClass.

Add unit tests for that.

cc @openshift/storage 
