### PR TITLE
Updating ose-csi-external-snapshotter builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,8 +1,8 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/kubernetes-csi/external-snapshotter
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/kubernetes-csi/external-snapshotter/bin/csi-snapshotter /usr/bin/
 ENTRYPOINT ["/usr/bin/csi-snapshotter"]


### PR DESCRIPTION
Updating ose-csi-external-snapshotter builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-csi-external-snapshotter.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.