### PR TITLE
UPSTREAM: 502: Bug 1949018: Correct snapshotContent error propagation

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -300,9 +300,9 @@ func (ctrl *csiSnapshotSideCarController) createSnapshotWrapper(content *crdv1.V
 		// storage system has responded with an error
 		klog.Infof("createSnapshotWrapper: CreateSnapshot for content %s returned error: %v", content.Name, err)
 		if isCSIFinalError(err) {
-			err = ctrl.removeAnnVolumeSnapshotBeingCreated(content)
-			if err != nil {
-				return nil, fmt.Errorf("failed to remove VolumeSnapshotBeingCreated annotation from the content %s: %q", content.Name, err)
+			removeAnnotationErr := ctrl.removeAnnVolumeSnapshotBeingCreated(content)
+			if removeAnnotationErr != nil {
+				return nil, fmt.Errorf("failed to remove VolumeSnapshotBeingCreated annotation from the content %s: %q", content.Name, removeAnnotationErr)
 			}
 		}
 


### PR DESCRIPTION
Backport of https://github.com/kubernetes-csi/external-snapshotter/pull/502 to OCP.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently if we fail to create a snapshot in a CSIFinalError way, the error is overwritten when we attempt to remove the annotation on the content. This can result in the snapshot controller logging the error, but subsequent logs (and events) being nil:

> I0420 18:59:30.106430       1 snapshot_controller.go:301] createSnapshotWrapper: CreateSnapshot for content snapcontent-5e494f19-ea35-480c-89f8-626e6ad1dbd3 returned error: rpc error: code = Unknown desc = AzureDisk - invalid option invalid in VolumeSnapshotClass
> ...
> E0420 18:59:30.506775       1 snapshot_controller.go:105] createSnapshot for content [snapcontent-5e494f19-ea35-480c-89f8-626e6ad1dbd3]: error occurred in createSnapshotWrapper: failed to take snapshot of the volume, ...%!q(<nil>)

We don't see any Events with the correct error logged. By changing the error we're able to get the events correctly created. There are still periodic issues with stale resources, but these are addressed by changing to Patch (or by performing a Get in `updateContentErrorStatusWithEvent`). These changes are being made in https://github.com/kubernetes-csi/external-snapshotter/pull/480 , and therefore I didn't include them here.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
VolumeSnapshotContent creation errors can now propagate to the appropriate VolumeSnapshotContent resource.
```