### PR TITLE
OCPBUGS-24244: Move builder and base image to RHEL 9

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.15
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,8 +1,8 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/kubernetes-csi/external-snapshotter
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.15:base
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 COPY --from=builder /go/src/github.com/kubernetes-csi/external-snapshotter/bin/csi-snapshotter /usr/bin/
 ENTRYPOINT ["/usr/bin/csi-snapshotter"]


### PR DESCRIPTION
There are some conflict PRs and this will move builder and base image to RHEL 9.