### PR TITLE
OCPBUGS-29433: cherry-pick:release-4.14: OCPBUGS-29244 Update VolumeSnapshot and VolumeSnapshotContent using JSON patch

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1380,8 +1380,15 @@ func (ctrl *csiSnapshotCommonController) SetDefaultSnapshotClass(snapshot *crdv1
 	}
 	klog.V(5).Infof("setDefaultSnapshotClass [%s]: default VolumeSnapshotClassName [%s]", snapshot.Name, defaultClasses[0].Name)
 	snapshotClone := snapshot.DeepCopy()
-	snapshotClone.Spec.VolumeSnapshotClassName = &(defaultClasses[0].Name)
-	newSnapshot, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
+	patches := []utils.PatchOp{
+		{
+			Op:    "replace",
+			Path:  "/spec/volumeSnapshotClassName",
+			Value: &(defaultClasses[0].Name),
+		},
+	}
+
+	newSnapshot, err := utils.PatchVolumeSnapshot(snapshotClone, patches, ctrl.clientset)
 	if err != nil {
 		klog.V(4).Infof("updating VolumeSnapshot[%s] default class failed %v", utils.SnapshotKey(snapshot), err)
 	}
@@ -1605,18 +1612,24 @@ func (ctrl *csiSnapshotCommonController) checkAndSetInvalidContentLabel(content 
 		return content, nil
 	}
 
+	var patches []utils.PatchOp
 	contentClone := content.DeepCopy()
 	if hasLabel {
 		// Need to remove the label
-		delete(contentClone.Labels, utils.VolumeSnapshotContentInvalidLabel)
+		patches = append(patches, utils.PatchOp{
+			Op:   "remove",
+			Path: "/metadata/labels/" + utils.VolumeSnapshotContentInvalidLabel,
+		})
+
 	} else {
 		// Snapshot content is invalid and does not have the label. Need to add the label
-		if contentClone.ObjectMeta.Labels == nil {
-			contentClone.ObjectMeta.Labels = make(map[string]string)
-		}
-		contentClone.ObjectMeta.Labels[utils.VolumeSnapshotContentInvalidLabel] = ""
+		patches = append(patches, utils.PatchOp{
+			Op:    "add",
+			Path:  "/metadata/labels/" + utils.VolumeSnapshotContentInvalidLabel,
+			Value: "",
+		})
 	}
-	updatedContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Update(context.TODO(), contentClone, metav1.UpdateOptions{})
+	updatedContent, err := utils.PatchVolumeSnapshotContent(contentClone, patches, ctrl.clientset)
 	if err != nil {
 		return content, newControllerUpdateError(content.Name, err.Error())
 	}
@@ -1646,19 +1659,24 @@ func (ctrl *csiSnapshotCommonController) checkAndSetInvalidSnapshotLabel(snapsho
 		return snapshot, nil
 	}
 
+	var patches []utils.PatchOp
 	snapshotClone := snapshot.DeepCopy()
 	if hasLabel {
 		// Need to remove the label
-		delete(snapshotClone.Labels, utils.VolumeSnapshotInvalidLabel)
+		patches = append(patches, utils.PatchOp{
+			Op:   "remove",
+			Path: "/metadata/labels/" + utils.VolumeSnapshotInvalidLabel,
+		})
 	} else {
 		// Snapshot is invalid and does not have the label. Need to add the label
-		if snapshotClone.ObjectMeta.Labels == nil {
-			snapshotClone.ObjectMeta.Labels = make(map[string]string)
-		}
-		snapshotClone.ObjectMeta.Labels[utils.VolumeSnapshotInvalidLabel] = ""
+		patches = append(patches, utils.PatchOp{
+			Op:    "add",
+			Path:  "/metadata/labels/" + utils.VolumeSnapshotInvalidLabel,
+			Value: "",
+		})
 	}
 
-	updatedSnapshot, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshot.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
+	updatedSnapshot, err := utils.PatchVolumeSnapshot(snapshotClone, patches, ctrl.clientset)
 	if err != nil {
 		return snapshot, newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
 	}

--- a/pkg/common-controller/snapshot_finalizer_test.go
+++ b/pkg/common-controller/snapshot_finalizer_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package common_controller
 
 import (
-	"testing"
-
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/utils"
 	v1 "k8s.io/api/core/v1"
+	"testing"
 )
 
 // Test single call to ensurePVCFinalizer, checkandRemovePVCFinalizer, addSnapshotFinalizer, removeSnapshotFinalizer


### PR DESCRIPTION
Cherry-pick of commit ff71329 to branch release-4.14 to reduce flakes as seen in https://github.com/openshift/oadp-operator/pull/1277
    OCPBUGS-29244