### PR TITLE
OCPBUGS-31599: add cmdline args to enable group snapshot webhooks

### DIFF
--- a/deploy/kubernetes/webhook-example/webhook.yaml
+++ b/deploy/kubernetes/webhook-example/webhook.yaml
@@ -21,7 +21,11 @@ spec:
       - name: snapshot-validation
         image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1 # change the image if you wish to use your own custom validation server image
         imagePullPolicy: IfNotPresent
-        args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key']
+        args:
+        - '--tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt'
+        - '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key'
+        # uncomment the following line to enable webhook for VolumeGroupSnapshot, VolumeGroupSnapshotContent and VolumeGroupSnapshotClass.
+        # - '--enable-volume-group-snapshot-webhook'
         ports:
         - containerPort: 443 # change the port as needed
         volumeMounts:


### PR DESCRIPTION
This cherry-picks https://github.com/kubernetes-csi/external-snapshotter/commit/aafc4565272156ef39850b67349a74a2e1b37d55 into 4.15 so that the VolumeGroupSnapshot informers will be disabled in the webhook by default. VolumeGroupSnapshot's are alpha and not supported on 4.15 and previous versions.

Required by https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/203

/cc @openshift/storage @bertinatto @Phaow
