### PR TITLE
OCPBUGS-38322: Clean up Raunak message

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1165,7 +1165,6 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotStatus(snapshot *crdv1.Vo
 		updated = true
 	} else {
 		newStatus = snapshotObj.Status.DeepCopy()
-		klog.Infof("Raunak 1 %s", newStatus.VolumeGroupSnapshotName)
 		if newStatus.BoundVolumeSnapshotContentName == nil {
 			newStatus.BoundVolumeSnapshotContentName = &boundContentName
 			updated = true


### PR DESCRIPTION
This message is removed upstream and in newer openshift versions:
 * https://github.com/kubernetes-csi/external-snapshotter/pull/882
 * https://github.com/openshift/csi-external-snapshotter/pull/139