### PR TITLE
STOR-2281: Remove csi-snapshot-validation-webhook

### DIFF
--- a/Dockerfile.webhook.openshift.rhel7
+++ b/Dockerfile.webhook.openshift.rhel7
@@ -1,8 +1,0 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
-WORKDIR /go/src/github.com/kubernetes-csi/external-snapshotter
-COPY . .
-RUN make build
-
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
-COPY --from=builder /go/src/github.com/kubernetes-csi/external-snapshotter/bin/snapshot-controller /usr/bin/
-ENTRYPOINT ["/usr/bin/snapshot-controller"]


### PR DESCRIPTION
Remove csi-snapshot-validation-webhook image no longer used.