### PR TITLE
OCPBUGS-77492: UPSTREAM: 1392: Fix VolumeSnapshotContent deletion

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -684,6 +684,15 @@ func ShouldEnqueueContentChange(old *crdv1.VolumeSnapshotContent, new *crdv1.Vol
 	if old.ResourceVersion == new.ResourceVersion {
 		return true
 	}
+	// Always enqueue VSC that just changed to "readyToUse".
+	// This will process any deletionTimestamp on the VSC that was added while the snapshot was being created.
+	// See https://github.com/kubernetes-csi/external-snapshotter/issues/1388
+	oldReadyToUse := old.Status != nil && old.Status.ReadyToUse != nil && *old.Status.ReadyToUse
+	newReadyToUse := new.Status != nil && new.Status.ReadyToUse != nil && *new.Status.ReadyToUse
+	if !oldReadyToUse && newReadyToUse {
+		return true
+	}
+
 	sanitized := new.DeepCopy()
 	// ResourceVersion always changes between revisions
 	sanitized.ResourceVersion = old.ResourceVersion

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -23,6 +23,7 @@ import (
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestRemoveString(t *testing.T) {
@@ -499,6 +500,26 @@ func TestShouldEnqueueContentChange(t *testing.T) {
 			new: &crdv1.VolumeSnapshotContent{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: oldValue,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "readyToUse transition from false to true (should enqueue to process deletionTimestamp)",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: oldValue,
+				},
+				Status: &crdv1.VolumeSnapshotContentStatus{
+					ReadyToUse: ptr.To(false),
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: newValue,
+				},
+				Status: &crdv1.VolumeSnapshotContentStatus{
+					ReadyToUse: ptr.To(true),
 				},
 			},
 			expectedResult: true,


### PR DESCRIPTION
Re-process a VolumeSnapshotContent (VSC) that got its deletionTimestamp while the external-snapshotter was still trying to provision.

In other words, enqueue informer events that change readyToUse to `true` - the snapshot is fully taken. The workqueue will check its deletionTimestamp.

This is a clean cherry-pick of  usptream [1392](https://github.com/kubernetes-csi/external-snapshotter/commit/e8f68491852cd991d97cf6e235a26db30302571e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization handling for volume snapshot content status transitions, ensuring content that becomes ready to use is properly enqueued.

* **Tests**
  * Added test coverage for volume snapshot content status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->