### PR TITLE
OCPBUGS-99009: [external-snapshotter] SnapshotContentObjectDeleteError event fired when VolumeSnapshotContent is already deleted

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -330,7 +330,7 @@ func (ctrl *csiSnapshotCommonController) checkandRemoveSnapshotFinalizersAndChec
 	if content != nil && deleteContent {
 		klog.V(5).Infof("checkandRemoveSnapshotFinalizersAndCheckandDeleteContent: set DeletionTimeStamp on content [%s].", content.Name)
 		err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Delete(context.TODO(), content.Name, metav1.DeleteOptions{})
-		if err != nil {
+		if err != nil && !apierrs.IsNotFound(err) {
 			ctrl.eventRecorder.Event(snapshot, v1.EventTypeWarning, "SnapshotContentObjectDeleteError", "Failed to delete snapshot content API object")
 			return fmt.Errorf("failed to delete VolumeSnapshotContent %s from API server: %q", content.Name, err)
 		}


### PR DESCRIPTION
When deleting a VolumeSnapshotContent or VolumeGroupSnapshotContent, the controller fires a spurious SnapshotContentObjectDeleteError or GroupSnapshotContentObjectDeleteError warning event if the object is already deleted (API returns NotFound). This happens during concurrent snapshot deletions when the sidecar removes the content before the common controller re-reconciles.

Add an apierrs.IsNotFound check before emitting the warning event, consistent with the existing pattern for VolumeSnapshot deletion in groupsnapshot_controller_helper.go

https://github.com/kubernetes-csi/external-snapshotter/pull/1460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot cleanup reliability by allowing reconciliation to continue when the associated content has already been deleted.
  * Other deletion failures continue to be reported for investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->